### PR TITLE
Modified paper to use 3D GPE by default for generality

### DIFF
--- a/paper.md
+++ b/paper.md
@@ -29,11 +29,11 @@ Numerical simulations of BECs allow for new discoveries that directly mimic what
 In practice, the dynamics of BEC systems can often be found by solving the non-linear Schr&ouml;dinger equation known as the Gross--Pitaevskii Equation (GPE),
 
 $$
-i\hbar \frac{\partial\Psi(x,t)}{\partial t} = \left( -\frac{\hbar^2}{2m} \frac{\partial}{\partial x^2} + V(x) + g|\Psi(x,t)|^2\right)\Psi(x,t),
+i\hbar \frac{\partial\Psi(\mathbf{r},t)}{\partial t} = \left( -\frac{\hbar^2}{2m} {\nabla^2} + V(\mathbf{r}) + g|\Psi(\mathbf{r},t)|^2\right)\Psi(\mathbf{r},t),
 $$
 
-where $\Psi(x,t)$ is the one-dimensional many-body wavefunction of the quantum system, $m$ is the atomic mass, $V(x)$ is a potential to trap the atomic system, $g = \frac{4\pi\hbar^2a_s}{m}$ is a coupling factor, and $a_s$ is the scattering length of the atomic species.
-Here, the GPE is shown in one dimension, but it can easily be extended to two or three dimensions.
+where $\Psi(\mathbf{r},t)$ is the three-dimensional many-body wavefunction of the quantum system, $\mathbf{r} = (x,y,z)$, $m$ is the atomic mass, $V(\mathbf{r})$ is an external potential, $g = \frac{4\pi\hbar^2a_s}{m}$ is a coupling factor, and $a_s$ is the scattering length of the atomic species.
+Here, the GPE is shown in three dimensions, but it can easily be modified to one or two dimensions [@PethickSmith2008].
 Though there are many methods to solve the GPE, one of the most straightforward is the split-operator method, which has previously been accelerated with GPU devices [@Ruf2009; @Bauke2011]; however, there are no generalized software packages available using this method on GPU devices that allow for user-configurable simulations and a variety of different system types.
 Even so, there are several software packages designed to simulate BECs with other methods, including GPELab [@Antoine2014] the Massively Parallel Trotter-Suzuki Solver [@Wittek2013], and XMDS [@xmds].
 


### PR DESCRIPTION
To ensure generality of the given GP equation, I have modified it to 3D, and referenced Pethick and Smith for considering modifications for 1 and 2D cases.
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/mlxd%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/858615%3Fv%3D4%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/GPUE-group/GPUE/pull/15%23issuecomment-438963165%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222018-11-15T08%3A47%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/858615%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mlxd%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/GPUE-group/GPUE/pull/15%23issuecomment-438963165%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/mlxd'><img src='https://avatars2.githubusercontent.com/u/858615?v=4' width=34 height=34></a>

<a href='https://www.codereviewhub.com/GPUE-group/GPUE/pull/15?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/GPUE-group/GPUE/pull/15?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/GPUE-group/GPUE/pull/15'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>