### PR TITLE
Energy cutoff threshold feature

### DIFF
--- a/src/evolution.cu
+++ b/src/evolution.cu
@@ -394,8 +394,6 @@ void evolve(Grid &par,
         if(i % printSteps == 0) {
             // If the unit_test flag is on, we need a special case
             printf("Step: %d    Omega: %lf\n", i, omega_0);
-            cudaMemcpy(wfc, gpuWfc, sizeof(cufftDoubleComplex)*xDim*yDim*zDim, 
-                       cudaMemcpyDeviceToHost);
 
             // Printing out time of iteration
             end = clock();
@@ -838,10 +836,12 @@ void evolve(Grid &par,
 
             if (i != 0 && fabs(oldEnergy - energy) < energy_calc_threshold * oldEnergy) {
                 printf("Stopping early at step %d with energy %E\n", i, energy);
-                //break;
+                break;
             }
         }
     }
+
+    cudaMemcpy(wfc, gpuWfc, sizeof(cufftDoubleComplex)*xDim*yDim*zDim, cudaMemcpyDeviceToHost);
 
     par.store("wfc", wfc);
     par.store("wfc_gpu", gpuWfc);

--- a/src/evolution.cu
+++ b/src/evolution.cu
@@ -834,7 +834,7 @@ void evolve(Grid &par,
             }
             par.store("energy", energy);
 
-            if (i != 0 && fabs(oldEnergy - energy) < energy_calc_threshold * oldEnergy) {
+            if (i != 0 && fabs(oldEnergy - energy) < energy_calc_threshold * oldEnergy && gstate == 0) {
                 printf("Stopping early at step %d with energy %E\n", i, energy);
                 break;
             }

--- a/src/helpfile
+++ b/src/helpfile
@@ -12,9 +12,9 @@ Options:
 -c 2            Set coords (1, 2, 3 dimensions)
 -D 0.0          Set's offset for kill (-K flag) distance radially
 -d data         Set data directory - where to store / read data (here in data/)
--E 0.0001 123   Perform energy calculations, exiting early if the change in energy is sufficiently small.
-                    If no arguments are given, the calculation is performed as often as the printSteps.
-                    Otherwise the threshold for cutoff and frequency of calculation must be given, in that order.
+-E 0.0001 123   Perform energy calculations, exit groundstate simulations early
+                    The calculation frequency defaults to printSteps.
+                    Otherwise the threshold and frequency must be given.
 -e 1            Set esteps, number of real-time evolution steps
 -f              Unset write to file flag
 -G 1            Set GammaY, ratio of omega_y to omega_x

--- a/src/helpfile
+++ b/src/helpfile
@@ -12,7 +12,9 @@ Options:
 -c 2            Set coords (1, 2, 3 dimensions)
 -D 0.0          Set's offset for kill (-K flag) distance radially
 -d data         Set data directory - where to store / read data (here in data/)
--E              Perform energy calculation every writing step
+-E 0.0001 123   Perform energy calculations, exiting early if the change in energy is sufficiently small.
+                    If no arguments are given, the calculation is performed as often as the printSteps.
+                    Otherwise the threshold for cutoff and frequency of calculation must be given, in that order.
 -e 1            Set esteps, number of real-time evolution steps
 -f              Unset write to file flag
 -G 1            Set GammaY, ratio of omega_y to omega_x

--- a/src/parser.cu
+++ b/src/parser.cu
@@ -52,6 +52,8 @@ Grid parseArgs(int argc, char** argv){
     par.store("box_size", -0.01);
     par.store("found_sobel", false);
     par.store("energy_calc", false);
+    par.store("energy_calc_steps", 0);
+    par.store("energy_calc_threshold", -1.0);
     par.store("use_param_file", false);
     par.store("param_file","param.cfg");
     par.store("cyl_coord",false);
@@ -67,7 +69,7 @@ Grid parseArgs(int argc, char** argv){
     optind = 1;
 
     while ((opt = getopt (argc, argv, 
-           "b:d:D:C:x:y:w:m:G:g:e:T:t:n:p:rQ:L:Elsi:P:X:Y:O:k:WU:V:S:ahz:H:uA:v:Z:fc:F:K:R:q:I:j:J;")) !=-1)
+           "b:d:D:C:x:y:w:m:G:g:e:T:t:n:p:rQ:L:E::lsi:P:X:Y:O:k:WU:V:S:ahz:H:uA:v:Z:fc:F:K:R:q:I:j:J;")) !=-1)
     {
         switch (opt)
         {
@@ -76,7 +78,6 @@ Grid parseArgs(int argc, char** argv){
                 int xDim = atoi(optarg);
                 printf("Argument for x is given as %d\n",xDim);
                 par.store("xDim",(int)xDim);
-                break;
             }
             case 'b':
             {
@@ -228,8 +229,20 @@ Grid parseArgs(int argc, char** argv){
             }
             case 'E':
             {
-                printf("Printing energy calculation\n");
-                par.store("energy_calc",true);
+                if (optind >= argc || argv[optind][0] == '-') {
+                    printf("Energy tag set but no options given!\n");
+                } else {
+                    double threshold = atof(argv[optind]);
+                    int steps = atoi(argv[optind + 1]);
+
+                    printf("Calculating energy every %d steps, stopping if difference ratio is less than %E\n", steps, threshold);
+                    par.store("energy_calc",true);
+                    par.store("energy_calc_steps", steps);
+                    par.store("energy_calc_threshold", threshold);
+
+                    optind++;
+                }
+                par.store("energy_calc", true);
                 break;
             }
             case 'f':

--- a/src/unit_test.cu
+++ b/src/unit_test.cu
@@ -1245,8 +1245,8 @@ void evolve_test(){
 
     double thresh = 0.01;
     std::string buffer;
-    int gsteps = 24001;
-    int esteps = 24001;
+    int gsteps = 30001;
+    int esteps = 30001;
 
     par.store("gdt", 1e-4);
     par.store("dt", 1e-4);
@@ -1256,7 +1256,7 @@ void evolve_test(){
     par.store("omegaY", 1.0);
     par.store("esteps", esteps);
     par.store("gsteps", gsteps);
-    par.store("printSteps", 24000);
+    par.store("printSteps", 30000);
     par.store("write_file", false);
     par.store("write_it", true);
     par.store("energy_calc", true);

--- a/src/unit_test.cu
+++ b/src/unit_test.cu
@@ -1245,8 +1245,8 @@ void evolve_test(){
 
     double thresh = 0.01;
     std::string buffer;
-    int gsteps = 30001;
-    int esteps = 30001;
+    int gsteps = 24001;
+    int esteps = 24001;
 
     par.store("gdt", 1e-4);
     par.store("dt", 1e-4);
@@ -1256,7 +1256,7 @@ void evolve_test(){
     par.store("omegaY", 1.0);
     par.store("esteps", esteps);
     par.store("gsteps", gsteps);
-    par.store("printSteps", 30000);
+    par.store("printSteps", 24000);
     par.store("write_file", false);
     par.store("write_it", true);
     par.store("energy_calc", true);


### PR DESCRIPTION
- Implement the energy calculation cutoff such that if the change in energy between iterations is sufficiently small, the simulation stops early (when simulating imaginary time evolution).
This is set by the `-E` flag, described in the `helpfile`.
- Add the cutoff parameters to the unit tests

- Get rid of the f'n' dragons.