### PR TITLE
adding quick fix for energy calc / unit test.

### DIFF
--- a/src/simulator/evolution.cu
+++ b/src/simulator/evolution.cu
@@ -970,6 +970,7 @@ void evolve(Grid &par,
             break;
         }
     }
+    par.store("energy", energy);
     par.store("wfc_array", wfc_array);
     par.store("wfc_gpu_array", gpuWfc_array);
 

--- a/src/tests/unit_test.cu
+++ b/src/tests/unit_test.cu
@@ -1260,7 +1260,7 @@ void evolve_test(){
         evolve(par, gsteps);
 
         // Check that the energy is correct
-        double energy = par.dval("energy");
+        double energy = par.dvecval("energy").back();
         double energy_check = 0;
         energy_check = (double)i * 0.5 * HBAR * omegaX;
 
@@ -1275,7 +1275,7 @@ void evolve_test(){
         par.store("e_i", 0);
         set_variables(par);
         evolve(par, esteps);
-        double energy_ev = par.dval("energy");
+        double energy_ev = par.dvecval("energy").back();
 
         if (abs(energy - energy_ev) > thresh*energy_check){
             std::cout << "Energy is not constant in real-time for " 


### PR DESCRIPTION
I decided it was better to return the full energy vector from the energy calc and then just grab the last value of that for the test.